### PR TITLE
fix: mongo 2.18.1 raising ArgumentError

### DIFF
--- a/test/gridfs_test.rb
+++ b/test/gridfs_test.rb
@@ -7,7 +7,7 @@ describe Shrine::Storage::Gridfs do
   def gridfs(options = {})
     options[:client] ||= Mongo::Client.new("mongodb://127.0.0.1:27017/mydb", logger: Logger.new(nil))
 
-    Shrine::Storage::Gridfs.new(options)
+    Shrine::Storage::Gridfs.new(**options)
   end
 
   before do


### PR DESCRIPTION
Hi there! I came across an issue with one of the latest versions of mongo (2.18.1):

```
ArgumentError: Bulk write requests cannot be empty
/mongo-2.18.1/lib/mongo/bulk_write.rb:334:in `validate_requests!'
/mongo-2.18.1/lib/mongo/bulk_write.rb:62:in `execute'
/mongo-2.18.1/lib/mongo/collection.rb:726:in `bulk_write'
/mongo-2.18.1/lib/mongo/collection.rb:701:in `insert_many'
/mongo-2.18.1/lib/mongo/grid/fs_bucket.rb:177:in `insert_one'
/shrine-gridfs-1.0.1/lib/shrine/storage/gridfs.rb:138:in `create_file'
```

While trying to fix the issue, I found that the method used in `create_file` (`insert_one`) has been deprecated in favor of the `upload_from_stream` method.

Using that method I was able to simplify the code quite a bit. The test suite passes, but deleting this much code has me a bit worried 👀